### PR TITLE
Remove unused stop-when big bang option from m03-spider

### DIFF
--- a/lectures/m03-spider-solution.rkt
+++ b/lectures/m03-spider-solution.rkt
@@ -84,7 +84,6 @@ features.
   (big-bang s             ; Spider
     (on-tick   tock)      ; Spider -> Spider
     (to-draw   render)    ; Spider -> Image
-    ;(stop-when ...)      ; Spider -> Boolean
     ;(on-mouse  ...)      ; Spider Integer Integer MouseEvent -> Spider
     ;(on-key    ...)      ; Spider KeyEvent -> Spider
     ))

--- a/lectures/m03-spider-starter.rkt
+++ b/lectures/m03-spider-starter.rkt
@@ -69,7 +69,6 @@ features.
   (big-bang ws           ; WS
     (on-tick   tock)     ; WS -> WS
     (to-draw   render)   ; WS -> Image
-    (stop-when ...)      ; WS -> Boolean
     (on-mouse  ...)      ; WS Integer Integer MouseEvent -> WS
     (on-key    ...)))    ; WS KeyEvent -> WS
 


### PR DESCRIPTION
The `stop-when` big bang handler is no longer included in the HtDW recipe.